### PR TITLE
Add assigneeId to updatePost block

### DIFF
--- a/blocks/posts/updatePost.ts
+++ b/blocks/posts/updatePost.ts
@@ -87,6 +87,13 @@ export const updatePostBlock: AppBlock = {
           },
           required: false,
         },
+        assigneeId: {
+          name: "Assignee ID",
+          description:
+            "Featurebase admin ID to assign this post to (null to unassign)",
+          type: "string",
+          required: false,
+        },
       },
       onEvent: async (input) => {
         const params: FeaturebaseUpdatePostParams = {
@@ -101,6 +108,7 @@ export const updatePostBlock: AppBlock = {
           inReview: input.event.inputConfig.inReview,
           date: input.event.inputConfig.date,
           customInputValues: input.event.inputConfig.customInputValues,
+          assigneeId: input.event.inputConfig.assigneeId,
         };
 
         const response = await updatePost(

--- a/types.ts
+++ b/types.ts
@@ -203,6 +203,7 @@ export interface FeaturebaseUpdatePostParams {
   inReview?: boolean;
   date?: string;
   customInputValues?: Record<string, any>;
+  assigneeId?: string;
 }
 
 export interface FeaturebaseDeletePostParams {


### PR DESCRIPTION
## Summary
- Adds `assigneeId` field to the Update Post block, allowing posts to be assigned to Featurebase admins