### PR TITLE
Fix compatibility with Featurebase Nova API and webhook format

### DIFF
--- a/blocks/posts/getPost.ts
+++ b/blocks/posts/getPost.ts
@@ -1,5 +1,5 @@
 import { AppBlock, events } from "@slflows/sdk/v1";
-import { getPost } from "../../utils/apiHelpers.ts";
+import { FeaturebaseApiError, getPost } from "../../utils/apiHelpers.ts";
 import { buildGetPostOutput } from "../../schemas/common.ts";
 import { createApiConfig } from "../../utils/objectUtils.ts";
 
@@ -18,15 +18,28 @@ export const getPostBlock: AppBlock = {
         },
       },
       onEvent: async (input) => {
-        const response = await getPost(createApiConfig(input.app.config), {
-          id: input.event.inputConfig.id,
-        });
+        let response: unknown;
+        try {
+          response = await getPost(createApiConfig(input.app.config), {
+            id: input.event.inputConfig.id,
+          });
+        } catch (error) {
+          // Nova returns 404 for a nonexistent post id; preserve the block's
+          // historical "not found is not an error" contract.
+          if (error instanceof FeaturebaseApiError && error.statusCode === 404) {
+            await events.emit({ post: null, success: true, found: false });
+            return;
+          }
+          throw error;
+        }
 
-        // Check if we got a post (FeatureBase returns array or single object)
-        const post = Array.isArray((response as any)?.results)
-          ? (response as any)?.results[0]
-          : (response as any)?.results;
-        const found = !!post;
+        // Nova returns the Post object directly; the legacy API wrapped it
+        // in `results` (array or single object). Support both.
+        const raw = response as any;
+        const post = Array.isArray(raw?.results)
+          ? raw.results[0]
+          : (raw?.results ?? raw);
+        const found = !!(post && post.id);
 
         await events.emit({
           post: found ? post : null,

--- a/main.ts
+++ b/main.ts
@@ -87,13 +87,13 @@ const createWebhookValidator = (
       (payload as any).data === null ||
       !("item" in (payload as any).data) ||
       typeof (payload as any).data.item !== "object" ||
-      (payload as any).data.item === null ||
-      !("type" in (payload as any).data.item) ||
-      (payload as any).data.item.type !== expectedItemType
+      (payload as any).data.item === null
     ) {
       return false;
     }
-    return true;
+    // Nova-format payloads (2026) identify the item via `object`; legacy payloads via `type`
+    const item = (payload as any).data.item;
+    return (item.object ?? item.type) === expectedItemType;
   };
 };
 

--- a/utils/apiHelpers.ts
+++ b/utils/apiHelpers.ts
@@ -132,8 +132,12 @@ export async function makeFeaturebaseRequest(
     }
 
     if (!response.ok) {
+      const detail =
+        typeof responseData === "string"
+          ? responseData.slice(0, 300)
+          : JSON.stringify(responseData ?? "").slice(0, 300);
       throw new FeaturebaseApiError(
-        `Featurebase API error: ${response.status} ${response.statusText}`,
+        `Featurebase API error: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ""}`,
         response.status,
         responseData,
       );
@@ -164,10 +168,15 @@ export async function getPost(
   config: FeaturebaseApiConfig,
   params: { id: string },
 ) {
-  return makeFeaturebaseRequest(config, "/v2/posts", {
-    method: "GET",
-    queryParams: { id: params.id },
-  });
+  // Nova API (2026): retrieve-by-id is a path parameter; the old
+  // `GET /v2/posts?id=...` form is rejected with 400 Bad Request.
+  return makeFeaturebaseRequest(
+    config,
+    `/v2/posts/${encodeURIComponent(params.id)}`,
+    {
+      method: "GET",
+    },
+  );
 }
 
 export async function createPost(


### PR DESCRIPTION
## Problem

Featurebase versions its API/webhook conventions (`Featurebase-Version: 2026-01-01.nova`, previous version `2025-12-12.clover`). **Per Featurebase support, our organization's API version was switched to `2026-01-01.nova` on 2026-06-08** (org-level setting; webhooks always follow the org version, with no per-webhook pin). Under Nova the app breaks in both directions — confirmed against a production installation (Spacelift Product project, `featurebase-triage` flow) that worked on 2026-06-08 and was fully broken by 2026-07-02. Any org on Nova hits the same thing:

1. **All inbound webhook deliveries rejected with 400.** Nova payloads identify the item via `data.item.object` (e.g. `"post"`); the old `data.item.type` field no longer exists, so `createWebhookValidator` fails every payload and the handler responds `400 "Invalid <topic> event payload"`. Signature verification was never the issue (that path returns 401).
2. **`Get Post` block fails with `FeaturebaseApiError: 400 Bad Request`.** Retrieve-by-id is now `GET /v2/posts/{id}` (path parameter); the legacy `GET /v2/posts?id=...` query form the app uses is rejected.

Docs: [webhook payload structure](https://developers.featurebase.app/guides/webhooks/consuming), [retrieve post](https://developers.featurebase.app/api/resources/feedback/subresources/posts/methods/retrieve). Note their old docs domain (docs.featurebase.app) is dead; developers.featurebase.app is current.

## Changes

- **`main.ts`** — webhook validator accepts `data.item.object` (Nova) with fallback to `data.item.type` (legacy), so the app works with either payload format.
- **`utils/apiHelpers.ts`** — `getPost` uses the path-parameter endpoint; `FeaturebaseApiError` messages now include the response body (truncated to 300 chars) so API failures are diagnosable from flow logs — the bare `400 Bad Request` message made this incident much harder to root-cause.
- **`blocks/posts/getPost.ts`** — unwraps both the Nova (direct Post object) and legacy (`results` array/object) response shapes, and maps Nova's 404-for-nonexistent-id to the block's existing `found: false` contract.

`npx tsc --noEmit` passes.

## Known follow-ups (out of scope here)

- Nova renamed post fields (`user` → `author`, `category` → `boardId`, `pinned` → `isPinned`, `commentsAllowed` → `features.commentsEnabled`), so flows consuming these blocks' outputs may need expression updates after upgrading.
- Other blocks that pass ids as query params (e.g. custom fields, comments) may have the same `?id=` class of bug and should be audited against the Nova API reference.
- Consider pinning `Featurebase-Version: 2026-01-01.nova` on all outbound REST requests so app behavior is deterministic regardless of the org setting (support confirmed REST calls honor the header; webhooks follow the org version).

Featurebase support confirmed the timeline and mechanics on Spacelift's case: the org version switch (not a Featurebase-side default change) caused the breakage, `Featurebase-Version: 2025-12-12.clover` restores legacy REST behavior per request, and Clover has no deprecation date. This patch makes the app work on either version rather than depending on the org setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
